### PR TITLE
T11: Update database

### DIFF
--- a/database/database.sql
+++ b/database/database.sql
@@ -1,13 +1,12 @@
 CREATE DATABASE twitter_clone;
 
 CREATE TABLE app_user(
-    user_id SERIAL PRIMARY KEY,
-    display_name VARCHAR(100) NOT NULL,
-    email VARCHAR(100) NOT NULL UNIQUE,
-    password_hash VARCHAR(255) NOT NULL,
-    last_name VARCHAR(100) NOT NULL,
-    first_name VARCHAR(100) NOT NULL,
-    birth_date DATE NOT NULL
+    "userId" SERIAL PRIMARY KEY,
+    "displayName" VARCHAR(100),
+    "userName" VARCHAR(100) NOT NULL,
+    "email" VARCHAR(100) NOT NULL UNIQUE,
+    "birthDate" DATE,
+    "joinedDate" DATE NOT NULL
 );
 
 CREATE TABLE message(

--- a/database/database.sql
+++ b/database/database.sql
@@ -12,7 +12,7 @@ CREATE TABLE app_user(
 CREATE TABLE message(
     "messageId" SERIAL PRIMARY KEY,
     "messageTimestamp" TIMESTAMPTZ NOT NULL,
-    "textContext" TEXT,
+    "textContent" TEXT,
     "sentUserId" INT NOT NULL,
     CONSTRAINT "fkSentUserId"
         FOREIGN KEY("sentUserId")
@@ -103,32 +103,26 @@ VALUES ( 'Joe Anderson', 'Anderson', 'joe.anderson@gmail.com', '2021-03-08');
 
 
 /*Inserting Messages*/
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-12-27 21:26:39.023989-07', 'Hey. How are you?', 1, 2);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-12-27 21:30:55.023489-07', 'Im doing okay. What are you up to?', 2, 1);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-12-27 21:31:10.027424-07', 'Not much.. just work and school', 1, 2);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-12-27 21:31:52.027343-07', 'Looking forward to Christmas', 1, 2);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-11-10 10:22:53.027233-07', 'Going skating. Wanna come?', 3, 4);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-11-10 10:25:36.024285-07', 'Yea sure, when and where', 4, 3);
 
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
-VALUES ('2022-11-11 11:11:11.023285-07', 'I really liked your post', 5, 6);
-
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
+INSERT INTO message ("messageTimestamp", "textContent", "sentUserId", "receivedUserId")
 VALUES ('2022-12-27 21:32:22.027653-07', 'Same here', 2, 1);
-
-INSERT INTO message (message_timestamp, text_content, sent_user_id, received_user_id)
-VALUES ('2022-11-11 11:12:01.023745-07', 'Thanks. Put a lot of time into it', 6, 5);
 
 /*Inserting Message Media*/
 

--- a/database/database.sql
+++ b/database/database.sql
@@ -4,7 +4,7 @@ CREATE TABLE app_user(
     "userId" SERIAL PRIMARY KEY,
     "displayName" VARCHAR(100),
     "auth0Id" VARCHAR(100),
-    "userName" VARCHAR(100) NOT NULL,
+    "username" VARCHAR(100) NOT NULL,
     "email" VARCHAR(100) NOT NULL UNIQUE,
     "birthDate" DATE,
     "joinedDate" DATE NOT NULL
@@ -43,7 +43,7 @@ CREATE TABLE post(
     CONSTRAINT "fkParentPostId"
         FOREIGN KEY("parentPostId")
             REFERENCES post("postId"),
-    "postTimestamp" TIMESTAMPTZ NOT NULL,
+    "timestamp" TIMESTAMPTZ NOT NULL,
     "textContent" TEXT,
     "isRepost" BOOLEAN NOT NULL,
     "isQuotePost" BOOLEAN NOT NULL,
@@ -87,19 +87,19 @@ CREATE TABLE follow(
 
 
 /*Inserting User*/
-INSERT INTO app_user ( "displayName", "userName", "auth0Id", "email", "joinedDate", "birthDate")
+INSERT INTO app_user ( "displayName", "username", "auth0Id", "email", "joinedDate", "birthDate")
 VALUES ( 'John Doe', 'JohnDoe','auth|0f05fq5098g238', 'johndoe@gmail.com', '2023-01-08', '1999-01-08');
 
-INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+INSERT INTO app_user ( "displayName", "username","auth0Id", "email", "joinedDate", "birthDate")
 VALUES ( 'Michael Stewart', 'MStew','auth|dfg5245568g8jq','tracey.bond@gmail.com', '2022-05-18', '1980-05-22');
 
-INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+INSERT INTO app_user ( "displayName", "username","auth0Id", "email", "joinedDate", "birthDate")
 VALUES ( 'Benjamin Davidson', 'BenDavid123','auth|2gtunqa3113fvn','benjamin.davidson@gmail.com', '2023-02-04', '2001-10-02');
 
-INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+INSERT INTO app_user ( "displayName", "username","auth0Id", "email", "joinedDate", "birthDate")
 VALUES ( 'Alan Paterson', 'APaterson','auth|gjnca35769davn','alan.paterson@gmail.com', '2022-02-28', '2004-11-29');
 
-INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate")
+INSERT INTO app_user ( "displayName", "username","auth0Id", "email", "joinedDate")
 VALUES ( 'Joe Anderson', 'Anderson', 'auth|sdq315gb2cavcac','joe.anderson@gmail.com', '2021-03-08');
 
 
@@ -129,49 +129,49 @@ VALUES ('2022-12-27 21:32:22.027653-07', 'Same here', 2, 1);
 
 
 /*Inserting Post*/
-INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (1,'2022-12-25 10:40:36.024285-07', 'Merry Christmas', false, false, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 1, '2022-12-25 10:45:34.024632-07', 'Merry Christmas to you too', false, false, true);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 1, '2022-12-25 11:01:22.022342-07', 'Thanks John. You too.', false, false, true);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "isRepost", "isQuotePost", "isReply")
 VALUES (5, 3, '2022-12-30 17:04:45.022242-07', true, false, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "isRepost", "isQuotePost", "isReply")
 VALUES (1, 4, '2022-12-30 17:10:35.027442-07', true, false, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (1, 4, '2022-12-30 17:30:37.024452-07', 'I got some pretty good sales from there too, would recommend', false, true, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 4, '2022-12-30 17:37:42.024834-07', 'What did you get?', false, false, true);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 7, '2022-12-30 17:42:32.024848-07', 'Mario kart is awesome, you will have so much fun', false, false, true);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "isRepost", "isQuotePost", "isReply")
 VALUES (4, 8, '2022-12-30 17:50:12.024428-07', true, false, false);
 
-INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3,'2022-12-31 14:22:26.027885-07', 'New Years party is gonna be a blast', false, false, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 10, '2022-12-31 14:30:22.024956-07', 'So excited for this', false, false, true);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 9, '2022-12-31 14:36:32.028546-07', 'I love these games', false, false, true);
 
-INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (5,'2022-12-31 17:46:43.028646-07', 'Hockey is the best sport of all time!', false, false, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 8, '2022-12-31 17:55:33.028634-07', 'Based take', false, true, false);
 
-INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+INSERT INTO post ("userId", "parentPostId", "timestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 8, '2022-12-31 17:59:46.028434-07', 'Cant agree with you on this one', false, false, true);
 
 /*Inserting Follow*/

--- a/database/database.sql
+++ b/database/database.sql
@@ -128,145 +128,137 @@ VALUES ('2022-12-27 21:32:22.027653-07', 'Same here', 2, 1);
 
 
 /*Inserting Post*/
-INSERT INTO post (user_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (1,'2022-12-25 10:40:36.024285-07', 'Merry Christmas', false, false, false);
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 1, '2022-12-25 10:45:34.024632-07', 'Merry Christmas to you too', false, false, true);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 1, '2022-12-25 11:01:22.022342-07', 'Thanks John. You too.', false, false, true);
 
-INSERT INTO post (user_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (6, '2022-12-30 16:01:22.022342-07', 'Got a crazy boxing week sale on some games at GameStop', false, false, false);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
+VALUES (5, 3, '2022-12-30 17:04:45.022242-07', true, false, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, is_repost, is_quote_post, is_reply)
-VALUES (5, 4, '2022-12-30 17:04:45.022242-07', true, false, false);
-
-INSERT INTO post (user_id, parent_post_id, post_timestamp, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
 VALUES (1, 4, '2022-12-30 17:10:35.027442-07', true, false, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (1, 4, '2022-12-30 17:30:37.024452-07', 'I got some pretty good sales from there too, would recommend', false, true, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (2, 4, '2022-12-30 17:37:42.024834-07', 'What did you get?', false, false, true);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (6, 8, '2022-12-30 17:41:42.024378-07', 'I got mario kart and pokemon', false, false, true);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+VALUES (2, 7, '2022-12-30 17:42:32.024848-07', 'Mario kart is awesome, you will have so much fun', false, false, true);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (2, 9, '2022-12-30 17:42:32.024848-07', 'Mario kart is awesome, you will have so much fun', false, false, true);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "isRepost", "isQuotePost", "isReply")
+VALUES (4, 8, '2022-12-30 17:50:12.024428-07', true, false, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, is_repost, is_quote_post, is_reply)
-VALUES (4, 10, '2022-12-30 17:50:12.024428-07', true, false, false);
-
-INSERT INTO post (user_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3,'2022-12-31 14:22:26.027885-07', 'New Years party is gonna be a blast', false, false, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (3, 12, '2022-12-31 14:30:22.024956-07', 'So excited for this', false, false, true);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+VALUES (3, 10, '2022-12-31 14:30:22.024956-07', 'So excited for this', false, false, true);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (3, 12, '2022-12-31 14:30:22.024956-07', 'So excited for this', false, false, true);
-
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (3, 9, '2022-12-31 14:36:32.028546-07', 'I love these games', false, false, true);
 
-INSERT INTO post (user_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
+INSERT INTO post ("userId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
 VALUES (5,'2022-12-31 17:46:43.028646-07', 'Hockey is the best sport of all time!', false, false, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (2, 15, '2022-12-31 17:55:33.028634-07', 'Based take', false, true, false);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+VALUES (2, 8, '2022-12-31 17:55:33.028634-07', 'Based take', false, true, false);
 
-INSERT INTO post (user_id, parent_post_id, post_timestamp, text_content, is_repost, is_quote_post, is_reply)
-VALUES (3, 16, '2022-12-31 17:59:46.028434-07', 'Cant agree with you on this one', false, false, true);
+INSERT INTO post ("userId", "parentPostId", "postTimestamp", "textContent", "isRepost", "isQuotePost", "isReply")
+VALUES (3, 8, '2022-12-31 17:59:46.028434-07', 'Cant agree with you on this one', false, false, true);
 
 /*Inserting Follow*/
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 1, '2022-09-01', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 2, '2022-09-01', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (3, 1, '2022-09-04', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (3, 2, '2022-09-04', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (5, 3, '2022-09-07', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (3, 5, '2022-09-07', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 3, '2022-09-07', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 1, '2022-09-08', false);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 2, '2022-09-08', false);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (5, 1, '2022-09-10', false);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (5, 2, '2022-09-10', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 5, '2022-09-12', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 6, '2022-09-15', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 6, '2022-09-09', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (3, 6, '2022-09-10', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (6, 1, '2022-09-11', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (6, 2, '2022-09-20', false);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (6, 5, '2022-09-25', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 3, '2022-09-10', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 3, '2022-09-11', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (6, 3, '2022-09-14', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 4, '2022-09-11', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 4, '2022-09-09', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (3, 4, '2022-09-14', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (5, 4, '2022-09-22', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 5, '2022-09-11', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 5, '2022-09-17', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 6, '2022-09-26', true);
 
-INSERT INTO follow (follower_user_id, followed_user_id, followed_date, follow_status)
+INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (5, 6, '2022-09-13', true);
 
 /*Insert Liked Post*/

--- a/database/database.sql
+++ b/database/database.sql
@@ -24,64 +24,64 @@ CREATE TABLE message(
 );
 
 CREATE TABLE message_media(
-    message_id INT NOT NULL,
-    CONSTRAINT fk_message_id
-        FOREIGN KEY(message_id)
-            REFERENCES message(message_id),
-    link TEXT NOT NULL,
-    PRIMARY KEY(message_id, link)
+    "messageId" INT NOT NULL,
+    CONSTRAINT "fkMessageId"
+        FOREIGN KEY("messageId")
+            REFERENCES message("messageId"),
+    "link" TEXT NOT NULL,
+    PRIMARY KEY("messageId", "link")
 );
 
 CREATE TABLE post(
-    post_id SERIAL PRIMARY KEY,
-    user_id INT NOT NULL,
-     CONSTRAINT fk_user_id
-        FOREIGN KEY(user_id)
-            REFERENCES app_user(user_id),
-    parent_post_id INT,
-    CONSTRAINT fk_parent_post_id
-        FOREIGN KEY(parent_post_id)
-            REFERENCES post(post_id),
-    post_timestamp TIMESTAMPTZ NOT NULL,
-    text_content TEXT,
-    is_repost BOOLEAN NOT NULL,
-    is_quote_post BOOLEAN NOT NULL,
-    is_reply BOOLEAN NOT NULL
+    "postId" SERIAL PRIMARY KEY,
+    "userId" INT NOT NULL,
+     CONSTRAINT "fkUserId"
+        FOREIGN KEY("userId")
+            REFERENCES app_user("userId"),
+    "parentPostId" INT,
+    CONSTRAINT "fkParentPostId"
+        FOREIGN KEY("parentPostId")
+            REFERENCES post("postId"),
+    "postTimestamp" TIMESTAMPTZ NOT NULL,
+    "textContent" TEXT,
+    "isRepost" BOOLEAN NOT NULL,
+    "isQuotePost" BOOLEAN NOT NULL,
+    "isReply" BOOLEAN NOT NULL
 );
 
 CREATE TABLE post_media(
-    post_id INT NOT NULL,
-    CONSTRAINT fk_post_id
-        FOREIGN KEY(post_id)
-            REFERENCES post(post_id),
-    link TEXT NOT NULL,
-    PRIMARY KEY(post_id, link)
+    "postId" INT NOT NULL,
+    CONSTRAINT "fkPostId"
+        FOREIGN KEY("postId")
+            REFERENCES post("postId"),
+    "link" TEXT NOT NULL,
+    PRIMARY KEY("postId", "link")
 );
 
 CREATE TABLE liked_post(
-    user_id INT NOT NULL,
-    CONSTRAINT fk_user_id
-        FOREIGN KEY(user_id)
-            REFERENCES app_user(user_id),
-    post_id INT NOT NULL,
-    CONSTRAINT fk_post_id
-        FOREIGN KEY(post_id)
-            REFERENCES post(post_id),
-    PRIMARY KEY(user_id,post_id)
+    "userId" INT NOT NULL,
+    CONSTRAINT "fkUserId"
+        FOREIGN KEY("userId")
+            REFERENCES app_user("userId"),
+    "postId" INT NOT NULL,
+    CONSTRAINT "fkPostId"
+        FOREIGN KEY("postId")
+            REFERENCES post("postId"),
+    PRIMARY KEY("userId","postId")
 );
 
 CREATE TABLE follow(
-    follower_user_id INT NOT NULL,
-    CONSTRAINT fk_follower_user_id
-        FOREIGN KEY(follower_user_id)
-            REFERENCES app_user(user_id),
-    followed_user_id INT NOT NULL,
-    CONSTRAINT fk_followed_user_id
-        FOREIGN KEY(followed_user_id)
-            REFERENCES app_user(user_id),
-    followed_date DATE NOT NULL,
-    follow_status BOOLEAN NOT NULL,
-    PRIMARY KEY(follower_user_id, followed_user_id)
+    "followerUserId" INT NOT NULL,
+    CONSTRAINT "fkFollowerUserId"
+        FOREIGN KEY("followerUserId")
+            REFERENCES app_user("userId"),
+    "followedUserId" INT NOT NULL,
+    CONSTRAINT "fkFollowedUserId"
+        FOREIGN KEY("followedUserId")
+            REFERENCES app_user("userId"),
+    "followedDate" DATE NOT NULL,
+    "followStatus" BOOLEAN NOT NULL,
+    PRIMARY KEY("followerUserId", "followedUserId")
 );
 
 

--- a/database/database.sql
+++ b/database/database.sql
@@ -211,31 +211,10 @@ INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followS
 VALUES (2, 5, '2022-09-12', true);
 
 INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (2, 6, '2022-09-15', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (1, 6, '2022-09-09', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (3, 6, '2022-09-10', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (6, 1, '2022-09-11', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (6, 2, '2022-09-20', false);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (6, 5, '2022-09-25', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (2, 3, '2022-09-10', true);
 
 INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 3, '2022-09-11', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (6, 3, '2022-09-14', true);
 
 INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (1, 4, '2022-09-11', true);
@@ -255,66 +234,49 @@ VALUES (1, 5, '2022-09-11', true);
 INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 VALUES (4, 5, '2022-09-17', true);
 
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (4, 6, '2022-09-26', true);
-
-INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-VALUES (5, 6, '2022-09-13', true);
-
 /*Insert Liked Post*/
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (2, 1);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (3, 1);
-INSERT INTO liked_post (user_id, post_id)
+
+INSERT INTO liked_post ("userId", "postId")
 VALUES (5, 4);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (1, 4);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (6, 7);
-
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (2, 9);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (6, 10);
-
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (1, 9);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (4, 4);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (2, 10);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (1, 12);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (4, 12);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (6, 12);
-
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (3, 12);
 
-INSERT INTO liked_post (user_id, post_id)
+INSERT INTO liked_post ("userId", "postId")
 VALUES (3, 9);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (6, 14);
+INSERT INTO liked_post ("userId", "postId")
+VALUES (2, 13);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (2, 15);
+INSERT INTO liked_post ("userId", "postId")
+VALUES (5, 12);
 
-INSERT INTO liked_post (user_id, post_id)
-VALUES (5, 16);
-
-INSERT INTO liked_post (user_id, post_id)
-VALUES (1, 17);
+INSERT INTO liked_post ("userId", "postId")
+VALUES (1, 8);
 

--- a/database/database.sql
+++ b/database/database.sql
@@ -10,17 +10,17 @@ CREATE TABLE app_user(
 );
 
 CREATE TABLE message(
-    message_id SERIAL PRIMARY KEY,
-    message_timestamp TIMESTAMPTZ NOT NULL,
-    text_content TEXT,
-    sent_user_id INT NOT NULL,
-    CONSTRAINT fk_sent_user_id
-        FOREIGN KEY(sent_user_id)
-            REFERENCES app_user(user_id),
-    received_user_id INT NOT NULL,
-    CONSTRAINT fk_received_user_id
-        FOREIGN KEY(received_user_id)
-            REFERENCES app_user(user_id)
+    "messageId" SERIAL PRIMARY KEY,
+    "messageTimestamp" TIMESTAMPTZ NOT NULL,
+    "textContext" TEXT,
+    "sentUserId" INT NOT NULL,
+    CONSTRAINT "fkSentUserId"
+        FOREIGN KEY("sentUserId")
+            REFERENCES app_user("userId"),
+    "receivedUserId" INT NOT NULL,
+    CONSTRAINT "fkReceivedUserId"
+        FOREIGN KEY("receivedUserId")
+            REFERENCES app_user("userId")
 );
 
 CREATE TABLE message_media(

--- a/database/database.sql
+++ b/database/database.sql
@@ -86,23 +86,20 @@ CREATE TABLE follow(
 
 
 /*Inserting User*/
-INSERT INTO app_user (email, display_name, password_hash, last_name, first_name, birth_date)
-VALUES ('johndoe@gmail.com', 'JohnDoe', '234567', 'Doe', 'John', '1999-01-08');
+INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
+VALUES ( 'John Doe', 'JohnDoe','johndoe@gmail.com', '2023-01-08', '1999-01-08');
 
-INSERT INTO app_user (email, display_name, password_hash, last_name, first_name, birth_date)
-VALUES ('janedoe@gmail.com', 'JaneDoe', '234567', 'Doe', 'Jane', '1998-02-18');
+INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
+VALUES ( 'Michael Stewart', 'MStew','tracey.bond@gmail.com', '2022-05-18', '1980-05-22');
 
-INSERT INTO app_user (email, password_hash, last_name, first_name, birth_date)
-VALUES ('tracey.bond@gmail.com', '342522', 'Bond', 'Tracey', '1980-05-22');
+INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
+VALUES ( 'Benjamin Davidson', 'BenDavid123','benjamin.davidson@gmail.com', '2023-02-04', '2001-10-02');
 
-INSERT INTO app_user (email, password_hash, last_name, first_name, birth_date)
-VALUES ('benjamin.davidson@gmail.com', '76745756', 'Davidson', 'Benjamin', '2001-10-02');
+INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
+VALUES ( 'Alan Paterson', 'APaterson','alan.paterson@gmail.com', '2022-02-28', '2004-11-29');
 
-INSERT INTO app_user (email, password_hash, last_name, first_name, birth_date)
-VALUES ('alan.paterson@gmail.com', '573564422', 'Paterson', 'Alan', '2004-11-29');
-
-INSERT INTO app_user (email, password_hash, last_name, first_name, birth_date)
-VALUES ('joe.anderson@gmail.com', '9083432', 'Anderson', 'Joe', '2011-05-10');
+INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate")
+VALUES ( 'Joe Anderson', 'Anderson', 'joe.anderson@gmail.com', '2021-03-08');
 
 
 /*Inserting Messages*/

--- a/database/database.sql
+++ b/database/database.sql
@@ -3,6 +3,7 @@ CREATE DATABASE twitter_clone;
 CREATE TABLE app_user(
     "userId" SERIAL PRIMARY KEY,
     "displayName" VARCHAR(100),
+    "auth0Id" VARCHAR(100),
     "userName" VARCHAR(100) NOT NULL,
     "email" VARCHAR(100) NOT NULL UNIQUE,
     "birthDate" DATE,
@@ -86,20 +87,20 @@ CREATE TABLE follow(
 
 
 /*Inserting User*/
-INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
-VALUES ( 'John Doe', 'JohnDoe','johndoe@gmail.com', '2023-01-08', '1999-01-08');
+INSERT INTO app_user ( "displayName", "userName", "auth0Id", "email", "joinedDate", "birthDate")
+VALUES ( 'John Doe', 'JohnDoe','auth|0f05fq5098g238', 'johndoe@gmail.com', '2023-01-08', '1999-01-08');
 
-INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
-VALUES ( 'Michael Stewart', 'MStew','tracey.bond@gmail.com', '2022-05-18', '1980-05-22');
+INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+VALUES ( 'Michael Stewart', 'MStew','auth|dfg5245568g8jq','tracey.bond@gmail.com', '2022-05-18', '1980-05-22');
 
-INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
-VALUES ( 'Benjamin Davidson', 'BenDavid123','benjamin.davidson@gmail.com', '2023-02-04', '2001-10-02');
+INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+VALUES ( 'Benjamin Davidson', 'BenDavid123','auth|2gtunqa3113fvn','benjamin.davidson@gmail.com', '2023-02-04', '2001-10-02');
 
-INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate", "birthDate")
-VALUES ( 'Alan Paterson', 'APaterson','alan.paterson@gmail.com', '2022-02-28', '2004-11-29');
+INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate", "birthDate")
+VALUES ( 'Alan Paterson', 'APaterson','auth|gjnca35769davn','alan.paterson@gmail.com', '2022-02-28', '2004-11-29');
 
-INSERT INTO app_user ( "displayName", "userName", "email", "joinedDate")
-VALUES ( 'Joe Anderson', 'Anderson', 'joe.anderson@gmail.com', '2021-03-08');
+INSERT INTO app_user ( "displayName", "userName","auth0Id", "email", "joinedDate")
+VALUES ( 'Joe Anderson', 'Anderson', 'auth|sdq315gb2cavcac','joe.anderson@gmail.com', '2021-03-08');
 
 
 /*Inserting Messages*/


### PR DESCRIPTION
Closes #11. This PR changes the naming convention for all column names from snake case to camel case

Some alterations were also made to the database schema:
- Removed `password_hash`, `first_name`, and `last_name` columns from users table
- Add `auth0Id`, `username`, and `joinedDate` column to the users table
- Made `displayName` nullable