### PR TITLE
T38: Update post queries to include number of replies and reposts

### DIFF
--- a/models/PostModel.js
+++ b/models/PostModel.js
@@ -10,27 +10,29 @@ const getAllPosts = `WITH post_likes AS (
   FROM liked_post
   GROUP BY "postId"
   ),
-  post_replies AS (
-  	SELECT "parentPostId",
-	  COUNT(*)::INT AS "numberOfReplies"
+  post_replies_reposts AS (
+    SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies",
+	  COUNT(CASE WHEN "isRepost" = TRUE THEN 1 END) AS "numberOfReposts"
 	FROM post
 	WHERE "parentPostId" IS NOT NULL
 	GROUP BY "parentPostId"
   )
   SELECT p."postId",
-   u.username,
-   u."displayName",
-   p."textContent",
-   p.timestamp,
-   EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
-   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
-   FROM post AS p
-   LEFT JOIN post_likes AS l ON p."postId" = l."postId"
-   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
-   INNER JOIN app_user AS u ON p."userId" = u."userId"
-   WHERE p."parentPostId" IS NULL
-   ORDER BY p.timestamp DESC`;
+    u.username,
+    u."displayName",
+    p."textContent",
+    p.timestamp,
+    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
+    COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+    COALESCE(r."numberOfReplies", 0) AS "numberOfReplies",
+    COALESCE(r."numberOfReposts", 0) AS "numberOfReposts"
+  FROM post AS p
+  LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+  LEFT JOIN post_replies_reposts AS r ON p."postId" = r."parentPostId"
+  INNER JOIN app_user AS u ON p."userId" = u."userId"
+  WHERE p."parentPostId" IS NULL
+  ORDER BY p.timestamp DESC`;
 
 const getPost = `WITH post_likes AS (
   SELECT "postId", 
@@ -38,26 +40,28 @@ const getPost = `WITH post_likes AS (
   FROM liked_post
   GROUP BY "postId"
   ),
-  post_replies AS (
-  	SELECT "parentPostId",
-	  COUNT(*)::INT AS "numberOfReplies"
+  post_replies_reposts AS (
+    SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies",
+	  COUNT(CASE WHEN "isRepost" = TRUE THEN 1 END) AS "numberOfReposts"
 	FROM post
 	WHERE "parentPostId" IS NOT NULL
 	GROUP BY "parentPostId"
   )
   SELECT p."postId",
-   u.username,
-   u."displayName",
-   p."textContent",
-   p.timestamp,
-   EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
-   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
-   FROM post AS p
-   LEFT JOIN post_likes AS l ON p."postId" = l."postId"
-   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
-   INNER JOIN app_user AS u ON p."userId" = u."userId"
-   WHERE p."postId" = $2`;
+    u.username,
+    u."displayName",
+    p."textContent",
+    p.timestamp,
+    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
+    COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+    COALESCE(r."numberOfReplies", 0) AS "numberOfReplies",
+    COALESCE(r."numberOfReposts", 0) AS "numberOfReposts"
+  FROM post AS p
+  LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+  LEFT JOIN post_replies_reposts AS r ON p."postId" = r."parentPostId"
+  INNER JOIN app_user AS u ON p."userId" = u."userId"
+  WHERE p."postId" = $2`;
 
 const getReplies = `WITH post_likes AS (
   SELECT "postId", 
@@ -65,28 +69,30 @@ const getReplies = `WITH post_likes AS (
   FROM liked_post
   GROUP BY "postId"
   ),
-  post_replies AS (
-  	SELECT "parentPostId",
-	  COUNT(*)::INT AS "numberOfReplies"
+  post_replies_reposts AS (
+    SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies",
+	  COUNT(CASE WHEN "isRepost" = TRUE THEN 1 END) AS "numberOfReposts"
 	FROM post
 	WHERE "parentPostId" IS NOT NULL
 	GROUP BY "parentPostId"
   )
   SELECT p."postId",
-   u.username,
-   u."displayName",
-   p."textContent",
-   p.timestamp,
-   p."parentPostId",
-   EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
-   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
-   FROM post AS p
-   LEFT JOIN post_likes AS l ON p."postId" = l."postId"
-   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
-   INNER JOIN app_user AS u ON p."userId" = u."userId"
-   WHERE p."parentPostId" = $2
-   ORDER BY "numberOfLikes" DESC`;
+    u.username,
+    u."displayName",
+    p."textContent",
+    p.timestamp,
+    p."parentPostId",
+    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
+    COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+    COALESCE(r."numberOfReplies", 0) AS "numberOfReplies",
+    COALESCE(r."numberOfReposts", 0) AS "numberOfReposts"
+  FROM post AS p
+  LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+  LEFT JOIN post_replies_reposts AS r ON p."postId" = r."parentPostId"
+  INNER JOIN app_user AS u ON p."userId" = u."userId"
+  WHERE p."parentPostId" = $2
+  ORDER BY "numberOfLikes" DESC`;
 
 const likePost = `INSERT INTO liked_post ("userId", "postId") VALUES ($1, $2)`;
 

--- a/models/PostModel.js
+++ b/models/PostModel.js
@@ -9,6 +9,13 @@ const getAllPosts = `WITH post_likes AS (
 	COUNT(*)::INT AS "numberOfLikes"
   FROM liked_post
   GROUP BY "postId"
+  ),
+  post_replies AS (
+  	SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies"
+	FROM post
+	WHERE "parentPostId" IS NOT NULL
+	GROUP BY "parentPostId"
   )
   SELECT p."postId",
    u.username,
@@ -16,9 +23,11 @@ const getAllPosts = `WITH post_likes AS (
    p."textContent",
    p.timestamp,
    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes"
+   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
    FROM post AS p
    LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
    INNER JOIN app_user AS u ON p."userId" = u."userId"
    WHERE p."parentPostId" IS NULL
    ORDER BY p.timestamp DESC`;
@@ -28,6 +37,13 @@ const getPost = `WITH post_likes AS (
 	COUNT(*)::INT AS "numberOfLikes"
   FROM liked_post
   GROUP BY "postId"
+  ),
+  post_replies AS (
+  	SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies"
+	FROM post
+	WHERE "parentPostId" IS NOT NULL
+	GROUP BY "parentPostId"
   )
   SELECT p."postId",
    u.username,
@@ -35,9 +51,11 @@ const getPost = `WITH post_likes AS (
    p."textContent",
    p.timestamp,
    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes"
+   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
    FROM post AS p
    LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
    INNER JOIN app_user AS u ON p."userId" = u."userId"
    WHERE p."postId" = $2`;
 
@@ -46,6 +64,13 @@ const getReplies = `WITH post_likes AS (
 	COUNT(*)::INT AS "numberOfLikes"
   FROM liked_post
   GROUP BY "postId"
+  ),
+  post_replies AS (
+  	SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies"
+	FROM post
+	WHERE "parentPostId" IS NOT NULL
+	GROUP BY "parentPostId"
   )
   SELECT p."postId",
    u.username,
@@ -54,9 +79,11 @@ const getReplies = `WITH post_likes AS (
    p.timestamp,
    p."parentPostId",
    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes"
+   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
    FROM post AS p
    LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
    INNER JOIN app_user AS u ON p."userId" = u."userId"
    WHERE p."parentPostId" = $2
    ORDER BY "numberOfLikes" DESC`;

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -1,27 +1,43 @@
 const getOwnTweets = `WITH post_likes AS (
-    SELECT "postId", 
-      COUNT(*)::INT AS "numberOfLikes"
-    FROM liked_post
-    GROUP BY "postId"
-    )
-    SELECT p."postId",
-     u.username,
-     u."displayName",
-     p."textContent",
-     p.timestamp,
-     EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-     COALESCE(l."numberOfLikes",0) AS "numberOfLikes"
-     FROM post AS p
-     LEFT JOIN post_likes AS l ON p."postId" = l."postId"
-     INNER JOIN app_user AS u ON p."userId" = u."userId"
-     WHERE u."userId" = $1 AND p."parentPostId" IS NULL
-     ORDER BY p.timestamp DESC`;
+  SELECT "postId", 
+    COUNT(*)::INT AS "numberOfLikes"
+  FROM liked_post
+  GROUP BY "postId"
+  ),
+  post_replies AS (
+    SELECT "parentPostId",
+    COUNT(*)::INT AS "numberOfReplies"
+  FROM post
+  WHERE "parentPostId" IS NOT NULL
+  GROUP BY "parentPostId"
+  )
+  SELECT p."postId",
+    u.username,
+    u."displayName",
+    p."textContent",
+    p.timestamp,
+    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
+    COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+    COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
+    FROM post AS p
+    LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+    LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
+    INNER JOIN app_user AS u ON p."userId" = u."userId"
+    WHERE u."userId" = $1 AND p."parentPostId" IS NULL
+    ORDER BY p.timestamp DESC`;
 
 const getOwnReplies = `WITH post_likes AS (
   SELECT "postId", 
 	COUNT(*)::INT AS "numberOfLikes"
   FROM liked_post
   GROUP BY "postId"
+  ),
+  post_replies AS (
+  	SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies"
+	FROM post
+	WHERE "parentPostId" IS NOT NULL
+	GROUP BY "parentPostId"
   )
   SELECT p."postId",
    u.username,
@@ -29,9 +45,11 @@ const getOwnReplies = `WITH post_likes AS (
    p."textContent",
    p.timestamp,
    EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1) AS "isLikedByCurrentUser",
-   COALESCE(l."numberOfLikes",0) AS "numberOfLikes"
+   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
    FROM post AS p
    LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+   LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
    INNER JOIN app_user AS u ON p."userId" = u."userId"
    WHERE u."userId" = $1 AND p."parentPostId" IS NOT NULL
    ORDER BY p.timestamp DESC`;
@@ -41,19 +59,28 @@ const getOwnLikes = `WITH post_likes AS (
     COUNT(*)::INT AS "numberOfLikes"
   FROM liked_post
   GROUP BY "postId"
-)
-SELECT p."postId",
-  u.username,
-  u."displayName",
-  p."textContent",
-  p.timestamp,
-  true AS "isLikedByCurrentUser",
-  COALESCE(l."numberOfLikes", 0) AS "numberOfLikes"
-FROM post AS p
-LEFT JOIN post_likes AS l ON p."postId" = l."postId"
-INNER JOIN app_user AS u ON p."userId" = u."userId"
-AND EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1)
-ORDER BY p.timestamp DESC`;
+  ),
+  post_replies AS (
+  	SELECT "parentPostId",
+	  COUNT(*)::INT AS "numberOfReplies"
+	FROM post
+	WHERE "parentPostId" IS NOT NULL
+	GROUP BY "parentPostId"
+  )
+  SELECT p."postId",
+   u.username,
+   u."displayName",
+   p."textContent",
+   p.timestamp,
+   TRUE AS "isLikedByCurrentUser",
+   COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
+   COALESCE(r."numberOfReplies", 0) AS "numberOfReplies"
+  FROM post AS p
+  LEFT JOIN post_likes AS l ON p."postId" = l."postId"
+  LEFT JOIN post_replies AS r ON p."postId" = r."parentPostId"
+  INNER JOIN app_user AS u ON p."userId" = u."userId"
+  AND EXISTS(SELECT 1 FROM liked_post li WHERE li."userId" = $1 AND li."postId" = p."postId" LIMIT 1)
+  ORDER BY p.timestamp DESC`;
 
 const getProfileContents = `SELECT 
   (SELECT COUNT(*) FROM post WHERE "userId" = $1) AS "postCount",


### PR DESCRIPTION
Closes #38. Our post queries were updated to return the number of replies and reposts each post has

Going through this made me realize we have a lot of queries on the back end that are copy and pasted. It'd be a good idea to see if we can refactor the code to cut these repetitions out. I'll leave that for another ticket though!