### PR TITLE
T45: Follow/Unfollow queries, controller and routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Tweeter - Backend
+# Chirp - Backend
 
-Backend of Twitter clone
+Backend of Chirp

--- a/controllers/FollowController.js
+++ b/controllers/FollowController.js
@@ -1,0 +1,35 @@
+const pool = require("../database/db");
+const profileQueries = require("../models/FollowModel");
+
+const followUser = async (req, res) => {
+  try {
+    const { currentUserId, visitedUsername } = req.body;
+    const query = await pool.query(profileQueries.followUser, [
+      currentUserId,
+      visitedUsername,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
+const unfollowUser = async (req, res) => {
+  try {
+    const { currentUserId, visitedUsername } = req.body;
+    const query = await pool.query(profileQueries.unfollowUser, [
+      currentUserId,
+      visitedUsername,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
+module.exports = {
+  followUser,
+  unfollowUser,
+};

--- a/controllers/FollowController.js
+++ b/controllers/FollowController.js
@@ -3,10 +3,10 @@ const followQueries = require("../models/FollowModel");
 
 const followUser = async (req, res) => {
   try {
-    const { currentUserId, visitedUsername } = req.body;
+    const { currentUserId, visitedUserId } = req.body;
     const query = await pool.query(followQueries.followUser, [
       currentUserId,
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows[0]);
   } catch (error) {
@@ -17,10 +17,10 @@ const followUser = async (req, res) => {
 
 const unfollowUser = async (req, res) => {
   try {
-    const { currentUserId, visitedUsername } = req.body;
+    const { currentUserId, visitedUserId } = req.body;
     const query = await pool.query(followQueries.unfollowUser, [
       currentUserId,
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows[0]);
   } catch (error) {
@@ -31,12 +31,12 @@ const unfollowUser = async (req, res) => {
 
 const getFollowStatus = async (req, res) => {
   try {
-    const { currentUserId, visitedUsername } = req.body;
-    if ((currentUserId || visitedUsername) === undefined)
-      throw new Error("currentUserId or visitedUsername is undefined");
+    const { currentUserId, visitedUserId } = req.body;
+    if ((currentUserId || visitedUserId) === undefined)
+      throw new Error("currentUserId or visitedUserId is undefined");
     const query = await pool.query(followQueries.getFollowStatus, [
       currentUserId,
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows[0]);
   } catch (error) {

--- a/controllers/FollowController.js
+++ b/controllers/FollowController.js
@@ -32,8 +32,6 @@ const unfollowUser = async (req, res) => {
 const getFollowStatus = async (req, res) => {
   try {
     const { currentUserId, visitedUserId } = req.body;
-    if ((currentUserId || visitedUserId) === undefined)
-      throw new Error("currentUserId or visitedUserId is undefined");
     const query = await pool.query(followQueries.getFollowStatus, [
       currentUserId,
       visitedUserId,

--- a/controllers/FollowController.js
+++ b/controllers/FollowController.js
@@ -1,10 +1,10 @@
 const pool = require("../database/db");
-const profileQueries = require("../models/FollowModel");
+const followQueries = require("../models/FollowModel");
 
 const followUser = async (req, res) => {
   try {
     const { currentUserId, visitedUsername } = req.body;
-    const query = await pool.query(profileQueries.followUser, [
+    const query = await pool.query(followQueries.followUser, [
       currentUserId,
       visitedUsername,
     ]);
@@ -18,7 +18,23 @@ const followUser = async (req, res) => {
 const unfollowUser = async (req, res) => {
   try {
     const { currentUserId, visitedUsername } = req.body;
-    const query = await pool.query(profileQueries.unfollowUser, [
+    const query = await pool.query(followQueries.unfollowUser, [
+      currentUserId,
+      visitedUsername,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
+const getFollowStatus = async (req, res) => {
+  try {
+    const { currentUserId, visitedUsername } = req.body;
+    if ((currentUserId || visitedUsername) === undefined)
+      throw new Error("currentUserId or visitedUsername is undefined");
+    const query = await pool.query(followQueries.getFollowStatus, [
       currentUserId,
       visitedUsername,
     ]);
@@ -32,4 +48,5 @@ const unfollowUser = async (req, res) => {
 module.exports = {
   followUser,
   unfollowUser,
+  getFollowStatus,
 };

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -3,9 +3,9 @@ const profileQueries = require("../models/ProfileModel");
 
 const getUserPosts = async (req, res) => {
   try {
-    const { visitedUsername } = req.query;
+    const { visitedUserId } = req.query;
     const query = await pool.query(profileQueries.getUserPosts, [
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows);
   } catch (error) {
@@ -16,9 +16,9 @@ const getUserPosts = async (req, res) => {
 
 const getUserReplies = async (req, res) => {
   try {
-    const { visitedUsername } = req.query;
+    const { visitedUserId } = req.query;
     const query = await pool.query(profileQueries.getUserReplies, [
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows);
   } catch (error) {
@@ -29,9 +29,9 @@ const getUserReplies = async (req, res) => {
 
 const getUserLikes = async (req, res) => {
   try {
-    const { visitedUsername } = req.query;
+    const { visitedUserId } = req.query;
     const query = await pool.query(profileQueries.getUserLikes, [
-      visitedUsername,
+      visitedUserId,
     ]);
     res.send(query.rows);
   } catch (error) {

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -47,9 +47,54 @@ const getProfileContents = async (req, res) => {
   }
 };
 
+const getFollowStatus = async (req, res) => {
+  try {
+    const { userId, username } = req.query;
+    const query = await pool.query(profileQueries.getFollowStatus, [
+      userId,
+      username,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
+const followUser = async (req, res) => {
+  try {
+    const { userId, username } = req.body;
+    const query = await pool.query(profileQueries.followUser, [
+      userId,
+      username,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
+const unfollowUser = async (req, res) => {
+  try {
+    const { userId, username } = req.body;
+    const query = await pool.query(profileQueries.unfollowUser, [
+      userId,
+      username,
+    ]);
+    res.send(query.rows[0]);
+  } catch (error) {
+    console.log(error);
+    res.status(500).send(error);
+  }
+};
+
 module.exports = {
   getUserPosts,
   getUserReplies,
   getUserLikes,
   getProfileContents,
+  getFollowStatus,
+  followUser,
+  unfollowUser,
 };

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -3,8 +3,10 @@ const profileQueries = require("../models/ProfileModel");
 
 const getUserPosts = async (req, res) => {
   try {
-    const { username } = req.query;
-    const query = await pool.query(profileQueries.getUserPosts, [username]);
+    const { visitedUsername } = req.query;
+    const query = await pool.query(profileQueries.getUserPosts, [
+      visitedUsername,
+    ]);
     res.send(query.rows);
   } catch (error) {
     console.log(error);
@@ -14,8 +16,10 @@ const getUserPosts = async (req, res) => {
 
 const getUserReplies = async (req, res) => {
   try {
-    const { username } = req.query;
-    const query = await pool.query(profileQueries.getUserReplies, [username]);
+    const { visitedUsername } = req.query;
+    const query = await pool.query(profileQueries.getUserReplies, [
+      visitedUsername,
+    ]);
     res.send(query.rows);
   } catch (error) {
     console.log(error);
@@ -25,8 +29,10 @@ const getUserReplies = async (req, res) => {
 
 const getUserLikes = async (req, res) => {
   try {
-    const { username } = req.query;
-    const query = await pool.query(profileQueries.getUserLikes, [username]);
+    const { visitedUsername } = req.query;
+    const query = await pool.query(profileQueries.getUserLikes, [
+      visitedUsername,
+    ]);
     res.send(query.rows);
   } catch (error) {
     console.log(error);
@@ -36,52 +42,10 @@ const getUserLikes = async (req, res) => {
 
 const getProfileContents = async (req, res) => {
   try {
-    const { userId, username } = req.query;
+    const { currentUserId, visitedUsername } = req.query;
     const query = await pool.query(profileQueries.getProfileContents, [
-      userId,
-      username,
-    ]);
-    res.send(query.rows[0]);
-  } catch (error) {
-    console.log(error);
-    res.status(500).send(error);
-  }
-};
-
-const getFollowStatus = async (req, res) => {
-  try {
-    const { userId, username } = req.query;
-    const query = await pool.query(profileQueries.getFollowStatus, [
-      userId,
-      username,
-    ]);
-    res.send(query.rows[0]);
-  } catch (error) {
-    console.log(error);
-    res.status(500).send(error);
-  }
-};
-
-const followUser = async (req, res) => {
-  try {
-    const { userId, username } = req.body;
-    const query = await pool.query(profileQueries.followUser, [
-      userId,
-      username,
-    ]);
-    res.send(query.rows[0]);
-  } catch (error) {
-    console.log(error);
-    res.status(500).send(error);
-  }
-};
-
-const unfollowUser = async (req, res) => {
-  try {
-    const { userId, username } = req.body;
-    const query = await pool.query(profileQueries.unfollowUser, [
-      userId,
-      username,
+      currentUserId,
+      visitedUsername,
     ]);
     res.send(query.rows[0]);
   } catch (error) {
@@ -95,7 +59,4 @@ module.exports = {
   getUserReplies,
   getUserLikes,
   getProfileContents,
-  getFollowStatus,
-  followUser,
-  unfollowUser,
 };

--- a/controllers/ProfileController.js
+++ b/controllers/ProfileController.js
@@ -36,8 +36,9 @@ const getUserLikes = async (req, res) => {
 
 const getProfileContents = async (req, res) => {
   try {
-    const { username } = req.query;
+    const { userId, username } = req.query;
     const query = await pool.query(profileQueries.getProfileContents, [
+      userId,
       username,
     ]);
     res.send(query.rows[0]);

--- a/database/05_Update_Follow_Table.sql
+++ b/database/05_Update_Follow_Table.sql
@@ -1,0 +1,3 @@
+ALTER TABLE follow
+DROP COLUMN "followStatus",
+DROP COLUMN "followedDate";

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const userRoute = require("./routes/userRoutes");
 const postRoute = require("./routes/postRoutes");
 const profileRoute = require("./routes/profileRoutes");
 const messagesRoute = require("./routes/messagesRoutes");
+const followRoute = require("./routes/followRoutes");
 
 const verifyJwt = jwt({
   secret: jwks.expressJwtSecret({
@@ -64,5 +65,6 @@ app.use("/api/users", verifyJwt, currentUserCheck, userRoute);
 app.use("/api/posts", postRoute);
 app.use("/api/profile", profileRoute);
 app.use("/api/messages", messagesRoute);
+app.use("/api/follow/", followRoute);
 
 app.listen(port, () => console.log(`Listening on port ${port}....`));

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -1,7 +1,5 @@
 const followUser = `INSERT INTO follow ("followerUserId", "followedUserId")
-SELECT $1, "userId"
-FROM app_user
-WHERE "userId" = $2;
+VALUES ($1, $2)
 `;
 
 const unfollowUser = `DELETE FROM follow
@@ -10,11 +8,10 @@ AND "followedUserId" = $2;
 `;
 
 const getFollowStatus = `SELECT EXISTS (
-  SELECT 1 
-  FROM follow 
-  WHERE "followerUserId" = $1 
-  AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "userId" = $2)
-) AS "followStatus";
+  SELECT 1
+  FROM follow
+  WHERE "followerUserId" = $1 AND "followedUserId" = $2
+) as "followStatus";
 `;
 
 module.exports = {

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -1,0 +1,25 @@
+const followUser = `INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
+SELECT $1, "userId", CURRENT_DATE, TRUE
+FROM app_user
+WHERE "username" = $2
+ON CONFLICT ("followerUserId", "followedUserId")
+DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE
+RETURNING *;
+`;
+
+const unfollowUser = `WITH otherUser AS (
+SELECT "userId"
+FROM app_user
+WHERE "username" = $2
+LIMIT 1
+)
+UPDATE follow
+SET "followStatus" = FALSE
+WHERE "followerUserId" = $1
+AND "followedUserId" = (SELECT "userId" FROM otherUser)
+RETURNING *`;
+
+module.exports = {
+  followUser,
+  unfollowUser,
+};

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -19,7 +19,14 @@ WHERE "followerUserId" = $1
 AND "followedUserId" = (SELECT "userId" FROM otherUser)
 RETURNING *`;
 
+const getFollowStatus = `SELECT 
+"followStatus"
+FROM follow
+WHERE "followerUserId" = $1
+AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "username" = $2);`;
+
 module.exports = {
   followUser,
   unfollowUser,
+  getFollowStatus,
 };

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -3,8 +3,7 @@ SELECT $1, "userId", CURRENT_DATE, TRUE
 FROM app_user
 WHERE "userId" = $2
 ON CONFLICT ("followerUserId", "followedUserId")
-DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE
-RETURNING *;
+DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE;
 `;
 
 const unfollowUser = `WITH otherUser AS (
@@ -16,8 +15,7 @@ LIMIT 1
 UPDATE follow
 SET "followStatus" = FALSE
 WHERE "followerUserId" = $1
-AND "followedUserId" = (SELECT "userId" FROM otherUser)
-RETURNING *`;
+AND "followedUserId" = (SELECT "userId" FROM otherUser);`;
 
 const getFollowStatus = `SELECT 
 "followStatus"

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -1,7 +1,7 @@
 const followUser = `INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
 SELECT $1, "userId", CURRENT_DATE, TRUE
 FROM app_user
-WHERE "username" = $2
+WHERE "userId" = $2
 ON CONFLICT ("followerUserId", "followedUserId")
 DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE
 RETURNING *;
@@ -10,7 +10,7 @@ RETURNING *;
 const unfollowUser = `WITH otherUser AS (
 SELECT "userId"
 FROM app_user
-WHERE "username" = $2
+WHERE "userId" = $2
 LIMIT 1
 )
 UPDATE follow
@@ -23,7 +23,7 @@ const getFollowStatus = `SELECT
 "followStatus"
 FROM follow
 WHERE "followerUserId" = $1
-AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "username" = $2);`;
+AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "userId" = $2);`;
 
 module.exports = {
   followUser,

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -1,27 +1,21 @@
-const followUser = `INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-SELECT $1, "userId", CURRENT_DATE, TRUE
+const followUser = `INSERT INTO follow ("followerUserId", "followedUserId")
+SELECT $1, "userId"
 FROM app_user
-WHERE "userId" = $2
-ON CONFLICT ("followerUserId", "followedUserId")
-DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE;
+WHERE "userId" = $2;
 `;
 
-const unfollowUser = `WITH otherUser AS (
-SELECT "userId"
-FROM app_user
-WHERE "userId" = $2
-LIMIT 1
-)
-UPDATE follow
-SET "followStatus" = FALSE
+const unfollowUser = `DELETE FROM follow
 WHERE "followerUserId" = $1
-AND "followedUserId" = (SELECT "userId" FROM otherUser);`;
+AND "followedUserId" = $2;
+`;
 
-const getFollowStatus = `SELECT 
-"followStatus"
-FROM follow
-WHERE "followerUserId" = $1
-AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "userId" = $2);`;
+const getFollowStatus = `SELECT EXISTS (
+  SELECT 1 
+  FROM follow 
+  WHERE "followerUserId" = $1 
+  AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "userId" = $2)
+) AS "followStatus";
+`;
 
 module.exports = {
   followUser,

--- a/models/FollowModel.js
+++ b/models/FollowModel.js
@@ -1,18 +1,15 @@
 const followUser = `INSERT INTO follow ("followerUserId", "followedUserId")
-VALUES ($1, $2)
-`;
+VALUES ($1, $2)`;
 
 const unfollowUser = `DELETE FROM follow
 WHERE "followerUserId" = $1
-AND "followedUserId" = $2;
-`;
+AND "followedUserId" = $2;`;
 
 const getFollowStatus = `SELECT EXISTS (
   SELECT 1
   FROM follow
   WHERE "followerUserId" = $1 AND "followedUserId" = $2
-) as "followStatus";
-`;
+) as "followStatus";`;
 
 module.exports = {
   followUser,

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -135,45 +135,9 @@ FROM app_user AS a
 LEFT JOIN follow as f ON f."followerUserId" = $1 AND f."followedUserId" = a."userId"
 WHERE a."username" = $2`;
 
-const getFollowStatus = `SELECT 
-CASE 
-    WHEN EXISTS (
-        SELECT 1
-        FROM follow
-        WHERE "followerUserId" = $1
-          AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "username" = $2)
-          AND "followStatus" = TRUE
-    ) THEN TRUE
-    ELSE FALSE
-END AS "followStatus";`;
-
-const followUser = `INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
-SELECT $1, "userId", CURRENT_DATE, TRUE
-FROM app_user
-WHERE "username" = $2
-ON CONFLICT ("followerUserId", "followedUserId")
-DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE
-RETURNING *;
-`;
-
-const unfollowUser = `WITH otherUser AS (
-SELECT "userId"
-FROM app_user
-WHERE "username" = $2
-LIMIT 1
-)
-UPDATE follow
-SET "followStatus" = FALSE
-WHERE "followerUserId" = $1
-AND "followedUserId" = (SELECT "userId" FROM otherUser)
-RETURNING *`;
-
 module.exports = {
   getUserPosts,
   getUserReplies,
   getUserLikes,
   getProfileContents,
-  getFollowStatus,
-  followUser,
-  unfollowUser,
 };

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -101,14 +101,50 @@ a."bio",
 a."joinedDate",
 a."displayName",
 a."username",
-(SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId") AS "followerCount",
-(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId") AS "followingCount"
+(SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId" AND "followStatus" = TRUE ) AS "followerCount",
+(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId" AND "followStatus" = TRUE ) AS "followingCount"
 FROM app_user AS a
 WHERE a."username" = $1`;
+
+const getFollowStatus = `SELECT 
+CASE 
+    WHEN EXISTS (
+        SELECT 1
+        FROM follow
+        WHERE "followerUserId" = $1
+          AND "followedUserId" = (SELECT "userId" FROM app_user WHERE "username" = $2)
+          AND "followStatus" = TRUE
+    ) THEN TRUE
+    ELSE FALSE
+END AS "followStatus";`;
+
+const followUser = `INSERT INTO follow ("followerUserId", "followedUserId", "followedDate", "followStatus")
+SELECT $1, "userId", CURRENT_DATE, TRUE
+FROM app_user
+WHERE "username" = $2
+ON CONFLICT ("followerUserId", "followedUserId")
+DO UPDATE SET "followStatus" = TRUE, "followedDate" = CURRENT_DATE
+RETURNING *;
+`;
+
+const unfollowUser = `WITH otherUser AS (
+SELECT "userId"
+FROM app_user
+WHERE "username" = $2
+LIMIT 1
+)
+UPDATE follow
+SET "followStatus" = FALSE
+WHERE "followerUserId" = $1
+AND "followedUserId" = (SELECT "userId" FROM otherUser)
+RETURNING *`;
 
 module.exports = {
   getUserPosts,
   getUserReplies,
   getUserLikes,
   getProfileContents,
+  getFollowStatus,
+  followUser,
+  unfollowUser,
 };

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -129,9 +129,11 @@ a."joinedDate",
 a."displayName",
 a."username",
 (SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId" AND "followStatus" = TRUE ) AS "followerCount",
-(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId" AND "followStatus" = TRUE ) AS "followingCount"
+(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId" AND "followStatus" = TRUE ) AS "followingCount",
+f."followStatus" AS "followStatus"
 FROM app_user AS a
-WHERE a."username" = $1`;
+LEFT JOIN follow as f ON f."followerUserId" = $1 AND f."followedUserId" = a."userId"
+WHERE a."username" = $2`;
 
 const getFollowStatus = `SELECT 
 CASE 

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -1,5 +1,4 @@
-const getUserPosts = `
-  WITH post_likes AS (
+const getUserPosts = `WITH post_likes AS (
     SELECT "postId", 
       COUNT(*)::INT AS "numberOfLikes"
     FROM liked_post
@@ -40,8 +39,7 @@ const getUserPosts = `
   ORDER BY 
     p.timestamp DESC`;
 
-const getUserReplies = `
-  WITH post_likes AS (
+const getUserReplies = `WITH post_likes AS (
     SELECT "postId", 
       COUNT(*)::INT AS "numberOfLikes"
     FROM liked_post
@@ -82,8 +80,7 @@ const getUserReplies = `
   ORDER BY 
     p.timestamp DESC`;
 
-const getUserLikes = `
-  WITH post_likes AS (
+const getUserLikes = `WITH post_likes AS (
     SELECT "postId", 
       COUNT(*)::INT AS "numberOfLikes"
     FROM liked_post

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -129,12 +129,16 @@ a."joinedDate",
 a."displayName",
 a."username",
 a."userId",
-(SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId" AND "followStatus" = TRUE ) AS "followerCount",
-(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId" AND "followStatus" = TRUE ) AS "followingCount",
-f."followStatus" AS "followStatus"
-FROM app_user AS a
-LEFT JOIN follow as f ON f."followerUserId" = $1 AND f."followedUserId" = a."userId"
-WHERE a."username" = $2`;
+(SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId") AS "followerCount",
+(SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId") AS "followingCount",
+CASE
+    WHEN EXISTS (SELECT 1 FROM follow WHERE "followerUserId" = $1 AND "followedUserId" = a."userId") THEN TRUE
+    ELSE FALSE
+END AS "followStatus"
+FROM 
+app_user AS a
+WHERE 
+a."username" = $2;`;
 
 module.exports = {
   getUserPosts,

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -35,7 +35,7 @@ const getUserPosts = `
     LEFT JOIN post_replies_reposts AS r ON p."postId" = r."parentPostId"
     INNER JOIN app_user AS u ON p."userId" = u."userId"
   WHERE 
-    u."username" = $1 
+    u."userId" = $1 
     AND p."parentPostId" IS NULL
   ORDER BY 
     p.timestamp DESC`;
@@ -77,7 +77,7 @@ const getUserReplies = `
     LEFT JOIN post_replies_reposts AS r ON p."postId" = r."parentPostId"
     INNER JOIN app_user AS u ON p."userId" = u."userId"
   WHERE 
-    u."username" = $1 
+    u."userId" = $1 
     AND p."parentPostId" IS NOT NULL
   ORDER BY 
     p.timestamp DESC`;
@@ -116,7 +116,7 @@ const getUserLikes = `
     SELECT 1
     FROM liked_post li
     INNER JOIN app_user u on li."userId" = u."userId"
-    WHERE u."username" = $1
+    WHERE u."userId" = $1
     AND li."postId" = p."postId"
     LIMIT 1
   )

--- a/models/ProfileModel.js
+++ b/models/ProfileModel.js
@@ -128,6 +128,7 @@ a."bio",
 a."joinedDate",
 a."displayName",
 a."username",
+a."userId",
 (SELECT COUNT(*) FROM follow WHERE "followedUserId" = a."userId" AND "followStatus" = TRUE ) AS "followerCount",
 (SELECT COUNT(*) FROM follow WHERE "followerUserId" = a."userId" AND "followStatus" = TRUE ) AS "followingCount",
 f."followStatus" AS "followStatus"

--- a/routes/followRoutes.js
+++ b/routes/followRoutes.js
@@ -1,0 +1,10 @@
+const { Router } = require("express");
+
+const followController = require("../controllers/FollowController");
+
+const router = Router();
+
+router.put("/followUser", followController.followUser);
+router.put("/unfollowUser", followController.unfollowUser);
+
+module.exports = router;

--- a/routes/followRoutes.js
+++ b/routes/followRoutes.js
@@ -6,5 +6,5 @@ const router = Router();
 
 router.put("/followUser", followController.followUser);
 router.put("/unfollowUser", followController.unfollowUser);
-
+router.get("/getFollowStatus", followController.getFollowStatus);
 module.exports = router;

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -8,8 +8,5 @@ router.get("/getUserPosts", profileController.getUserPosts);
 router.get("/getUserReplies", profileController.getUserReplies);
 router.get("/getUserLikes", profileController.getUserLikes);
 router.get("/getProfileContents", profileController.getProfileContents);
-router.get("/getFollowStatus", profileController.getFollowStatus);
-router.put("/followUser", profileController.followUser);
-router.put("/unfollowUser", profileController.unfollowUser);
 
 module.exports = router;

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -8,5 +8,8 @@ router.get("/getUserPosts", profileController.getUserPosts);
 router.get("/getUserReplies", profileController.getUserReplies);
 router.get("/getUserLikes", profileController.getUserLikes);
 router.get("/getProfileContents", profileController.getProfileContents);
+router.get("/getFollowStatus", profileController.getFollowStatus);
+router.put("/followUser", profileController.followUser);
+router.put("/unfollowUser", profileController.unfollowUser);
 
 module.exports = router;


### PR DESCRIPTION
This PR solves #45. In this PR, we introduce:

- `getFollowStatus`
- `followUser`
- `unfollowUser`

as routes, queries and controller methods. 

We also update `getProfileContents` to retrieve accurate following and follower counts, and the followStatus between the current user and the viewed user. 