### PR TITLE
T64: Return followStatus property in expanded post endpoint

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,17 +5,23 @@ addresses, connecting the code's context with the problem it
 solves. Please see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
 for keywords to link an issue -->
 
+Linked issue here
+
 ## Summary
 
 <!-- Provide a concise summary "Why are the changes needed"?
 Include any relevant links, such as Jira tickets, Slack discussions,
 or design documents. -->
 
+Your summary here
+
 ## Changes Made
 
 <!-- Describe the specific changes that have been made in this pull
 request. Provide details on the approach taken to address the problem
 and any notable implementation details. -->
+
+Your changes made here
 
 <!-- Optional Sections -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@ or design documents. -->
 request. Provide details on the approach taken to address the problem
 and any notable implementation details. -->
 
-<!--> Optional Sections -->
+<!-- Optional Sections -->
 
 ## Screenshots
 

--- a/controllers/FollowController.js
+++ b/controllers/FollowController.js
@@ -4,6 +4,9 @@ const followQueries = require("../models/FollowModel");
 const followUser = async (req, res) => {
   try {
     const { currentUserId, visitedUserId } = req.body;
+    if (currentUserId === visitedUserId) {
+      throw new Error("A user cannot follow themselves");
+    }
     const query = await pool.query(followQueries.followUser, [
       currentUserId,
       visitedUserId,
@@ -18,6 +21,9 @@ const followUser = async (req, res) => {
 const unfollowUser = async (req, res) => {
   try {
     const { currentUserId, visitedUserId } = req.body;
+    if (currentUserId === visitedUserId) {
+      throw new Error("A user cannot unfollow themselves");
+    }
     const query = await pool.query(followQueries.unfollowUser, [
       currentUserId,
       visitedUserId,

--- a/models/PostModel.js
+++ b/models/PostModel.js
@@ -108,6 +108,15 @@ const getPost = `
         AND li."postId" = p."postId" 
       LIMIT 1
     ) AS "isLikedByCurrentUser",
+     CASE
+      WHEN EXISTS (
+        SELECT 1
+        FROM follow WHERE "followerUserId" = $1
+          AND "followedUserId" = u."userId"
+      )
+      THEN TRUE
+      ELSE FALSE
+    END AS "followStatus",
     COALESCE(l."numberOfLikes",0) AS "numberOfLikes",
     COALESCE(r."numberOfReplies", 0) AS "numberOfReplies",
     COALESCE(r."numberOfReposts", 0) AS "numberOfReposts"


### PR DESCRIPTION
## Related Issues

Closes #64  

## Summary

This is a hotfix for the `RelevantUsers` component on the sidebar. The front end expects a `followStatus` property to be returned from the expanded post endpoint, but the follow status was not being returned in the query

## Changes Made

By checking whether the active user follows any relevant users and returning the follow status, we are able to correctly identify whether the active user follows the relevant user in the expanded post

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you
want to highlight for the reviewer, include them in this section. -->

No additional notes
