### PR TITLE
T70: Return Bio, Joined Date and Follower Count in DM Query

### DIFF
--- a/models/MessagesModel.js
+++ b/models/MessagesModel.js
@@ -38,7 +38,15 @@ const getConversationList = `
 const getOtherUser = `
   SELECT
     username,
-    "displayName"
+    "displayName",
+    "bio",
+    "joinedDate",
+    (
+      SELECT
+        COUNT(*)
+      FROM follow
+      WHERE "followedUserId" = "userId"
+    ) AS "followerCount"
   FROM app_user
   WHERE "userId" = $1;
 `;

--- a/models/MessagesModel.js
+++ b/models/MessagesModel.js
@@ -45,9 +45,9 @@ const getOtherUser = `
       SELECT
         COUNT(*)
       FROM follow
-      WHERE "followedUserId" = "userId"
+      WHERE "followedUserId" = u."userId"
     ) AS "followerCount"
-  FROM app_user
+  FROM app_user as u
   WHERE "userId" = $1;
 `;
 


### PR DESCRIPTION
## Related Issues

Closes #70.

## Summary

This PR looks to return a user's bio, joined date and follower count alongside the other user data that gets queried for when selecting a conversation.

## Changes Made

Updated `getOtherUser` query to return `bio`, `joinedDate`, and `followerCount` of a given user.

<!-- Optional Sections -->

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

No additional screenshots

## Testing Instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

No additional testing instructions

## Special Notes for Your Reviewer(s)

<!-- If there are any specific instructions or considerations you
want to highlight for the reviewer, include them in this section. -->

No additional notes
